### PR TITLE
More documentation

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -17,6 +17,7 @@ public class DataSource: NSObject {
         }
 
         didSet {
+            assert(NSThread.isMainThread(), "You must access Static.DataSource from the main thread.")
             updateTableView()
         }
     }
@@ -24,6 +25,7 @@ public class DataSource: NSObject {
     /// Sections to use in the table view.
     public var sections: [Section] {
         didSet {
+            assert(NSThread.isMainThread(), "You must access Static.DataSource from the main thread.")
             refresh()
         }
     }

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 /// Table view data source.
+///
+/// You should always access this object from the main thread since it talks to UIKit.
 public class DataSource: NSObject {
 
     // MARK: - Properties
@@ -20,7 +22,7 @@ public class DataSource: NSObject {
     }
 
     /// Sections to use in the table view.
-    public var sections = [Section]() {
+    public var sections: [Section] {
         didSet {
             refresh()
         }
@@ -31,19 +33,18 @@ public class DataSource: NSObject {
 
     // MARK: - Initializers
 
+    /// Initialize with optional `tableView` and `sections`.
     public init(tableView: UITableView? = nil, sections: [Section]? = nil) {
-        super.init()
-
         self.tableView = tableView
+        self.sections = sections ?? []
 
-        if let sections = sections {
-            self.sections = sections
-        }
+        super.init()
 
         updateTableView()
     }
 
     deinit {
+        // nil out the table view to ensure the table view data source and delegate niled out
         tableView = nil
     }
 

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -28,6 +28,7 @@ public struct Row: Hashable, Equatable {
         /// Custom view
         case View(UIView)
 
+        /// Table view cell accessory type
         public var type: UITableViewCellAccessoryType {
             switch self {
             case DisclosureIndicator: return .DisclosureIndicator
@@ -38,6 +39,7 @@ public struct Row: Hashable, Equatable {
             }
         }
 
+        /// Accessory view
         public var view: UIView? {
             switch self {
             case View(let view): return view
@@ -45,6 +47,7 @@ public struct Row: Hashable, Equatable {
             }
         }
 
+        /// Selection block for accessory buttons
         public var selection: Selection? {
             switch self {
             case DetailDisclosureButton(let selection): return selection


### PR DESCRIPTION
The note about UIKit support is the main thing here. Originally, I was going to `dispatch_async` to the main queue for everything that touches UIKit, but that got complicated quick. I think it makes things harder to work with since everything is async. I'd rather consumers treat `DataSource` like any other UIKit class and only access it from the main queue.

Thoughts? @ayanonagon @hyperspacemark 