### PR TITLE
Workaround iOS 8 UITableViewController init bug

### DIFF
--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -1,19 +1,96 @@
 import UIKit
 
 /// Table view controller with a `DataSource` setup to use its `tableView`.
-public class TableViewController: UITableViewController {
+public class TableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
 
     // MARK: - Properties
+
+    /// Returns the table view managed by the controller object.
+    public let tableView: UITableView
+
+    /// A Boolean value indicating if the controller clears the selection when the table appears.
+    ///
+    /// The default value of this property is YES. When YES, the table view controller clears the table’s current selection when it receives a viewWillAppear: message. Setting this property to NO preserves the selection.
+    public var clearsSelectionOnViewWillAppear: Bool = true
 
     /// Table view data source.
     public let dataSource = DataSource()
 
 
+    // MARK: - Initialization
+
+    public init(style: UITableViewStyle) {
+        tableView = UITableView(frame: .zeroRect, style: style)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+        tableView = UITableView(frame: .zeroRect, style: .Plain)
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public convenience init() {
+        self.init(style: .Plain)
+    }
+
+
     // MARK: - UIViewController
+
+    public override func loadView() {
+        tableView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        tableView.delegate = self
+        tableView.dataSource = self
+        view = tableView
+    }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-
         dataSource.tableView = tableView
+    }
+
+    public override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        performInitialLoad()
+        clearSelectionsIfNecessary()
+    }
+
+    public override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        tableView.flashScrollIndicators()
+    }
+
+    public override func setEditing(editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+        tableView.setEditing(editing, animated: animated)
+    }
+
+
+    // MARK: - UITableViewControllerDataSource
+
+    public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+
+    public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        return UITableViewCell(style: .Default, reuseIdentifier: nil)
+    }
+
+
+    // MARK: - Private
+
+    private var initialLoadOnceToken = dispatch_once_t()
+    private func performInitialLoad() {
+        dispatch_once(&initialLoadOnceToken) {
+            self.tableView.reloadData()
+        }
+    }
+
+    private func clearSelectionsIfNecessary() {
+        guard clearsSelectionOnViewWillAppear else { return }
+        tableView.indexPathsForSelectedRows?.forEach { tableView.deselectRowAtIndexPath($0, animated: true) }
     }
 }


### PR DESCRIPTION
* Make `TableViewController` inherit from `UIViewController`:

On iOS 8, `UITableViewController` incorrectly implements initialization chaining. In its implementation of `init(style:)`, it invokes `self.init(nibName: nibBundle:)` instead of calling up to `super`.

In Objective-C this isn't a problem since initializers are always inherited. In Swift, adding a required initializer effectively short circuits initializer inheritance causing the default implementation of `init(nibName: nibBundle:)` not to be inherited from `UIViewController`. The end result is that subclasses that add a required initializer that calls up to `init(style:)` crash on iOS 8 because that implementation then tries to invoke an `init(nibName: nibBundle:)` method on the subclass that is not implemented.

In many cases, it becomes impossible for consumer subclasses to implement that method and have their objects remain in a consistent state since there may not be a sensible default value for any property that is assigned with the argument provided to their required, designated initializer.