### PR TITLE
add judgement of table is nil

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -120,6 +120,8 @@ public class DataSource: NSObject {
     }
 
     private func refreshRegisteredCells() {
+        guard let tableView = tableView else { return }
+        
         // Filter to only rows with unregistered cells
         let rows = sections.map({ $0.rows }).reduce([], combine: +).filter() {
             !self.registeredCellIdentifiers.contains($0.cellIdentifier)
@@ -134,7 +136,7 @@ public class DataSource: NSObject {
             }
 
             registeredCellIdentifiers.insert(identifier)
-            tableView?.registerClass(row.cellClass, forCellReuseIdentifier: identifier)
+            tableView.registerClass(row.cellClass, forCellReuseIdentifier: identifier)
         }
     }
 }


### PR DESCRIPTION
If tableview is nil, the identifier also be inserted into registeredCellIdentifiers. Next time this method called, tableView can’t registerClass correctly.