### PR TITLE
Move nib declaration to `CellType` protocol

### DIFF
--- a/Example/CustomTableViewCell.swift
+++ b/Example/CustomTableViewCell.swift
@@ -2,24 +2,37 @@ import UIKit
 import Static
 
 class CustomTableViewCell: UITableViewCell, CellType {
+    private lazy var centeredLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .Center
+        label.textColor = .whiteColor()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
 
-    @IBOutlet weak var centeredLabel: UILabel!
-    
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.backgroundColor = .grayColor()
+
+        contentView.addSubview(centeredLabel)
+
+        let views = ["centeredLabel": centeredLabel]
+        var constraints: [NSLayoutConstraint] = NSLayoutConstraint.constraintsWithVisualFormat("|-[centeredLabel]-|", options: [], metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraintsWithVisualFormat("V:|-[centeredLabel]-|", options: [], metrics: nil, views: views)
+        NSLayoutConstraint.activateConstraints(constraints)
     }
 
-    override func setSelected(selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    
+
+    override func intrinsicContentSize() -> CGSize {
+        return CGSize(width: UIViewNoIntrinsicMetric, height: 80)
+    }
 }
 
 extension CellType where Self: CustomTableViewCell {
     func configure(row row: Row) {
-        centeredLabel?.text = row.text
+        centeredLabel.text = row.text
     }
 }

--- a/Example/NibTableViewCell.swift
+++ b/Example/NibTableViewCell.swift
@@ -1,0 +1,17 @@
+import UIKit
+import Static
+
+final class NibTableViewCell: UITableViewCell, CellType {
+
+    @IBOutlet weak var centeredLabel: UILabel!
+    
+    // MARK: - NibCellType
+
+    static func nib() -> UINib? {
+        return UINib(nibName: String(self), bundle: nil)
+    }
+
+    func configure(row row: Row) {
+        centeredLabel.text = row.text
+    }
+}

--- a/Example/NibTableViewCell.xib
+++ b/Example/NibTableViewCell.xib
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="15A279b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="CustomTableViewCell" customModule="Example" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="104" id="KGk-i7-Jjw" customClass="NibTableViewCell" customModule="Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="104"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Kr-e3-EF9">
-                        <rect key="frame" x="130" y="11" width="60" height="21"/>
+                        <rect key="frame" x="130" y="41" width="60" height="21"/>
                         <animations/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -23,14 +24,16 @@
                 </subviews>
                 <animations/>
                 <constraints>
-                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="TvJ-Yt-F1h"/>
-                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="si3-fF-73q"/>
+                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="0DV-UL-ORw"/>
+                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="33" id="S1U-RN-9XC"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="0Kr-e3-EF9" secondAttribute="bottom" constant="33" id="sGI-dG-GYf"/>
                 </constraints>
             </tableViewCellContentView>
             <animations/>
             <connections>
-                <outlet property="centeredLabel" destination="0Kr-e3-EF9" id="eep-kQ-JYH"/>
+                <outlet property="centeredLabel" destination="0Kr-e3-EF9" id="BTw-PS-u6X"/>
             </connections>
+            <point key="canvasLocation" x="883" y="636"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -36,8 +36,8 @@ class ViewController: TableViewController {
                 Row(text: "Button", detailText: "Detail", cellClass: ButtonCell.self, selection: { [unowned self] in
                     self.showAlert(title: "Row Selection")
                 }),
-                Row(text: "Custom", cellClass: CustomTableViewCell.self, cellNib: UINib(nibName: "CustomTableViewCell", bundle: nil)),
-                Row(text: "Custom with 64 height", cellClass: CustomTableViewCell.self, cellNib: UINib(nibName: "CustomTableViewCell", bundle: nil), height: 64)
+                Row(text: "Custom cell with explicit height", cellClass: CustomTableViewCell.self, height: 64),
+                Row(text: "Custom from nib", cellClass: NibTableViewCell.self)
             ], footer: "This is a section footer."),
             Section(header: "Accessories", rows: [
                 Row(text: "None"),

--- a/Static.xcodeproj/project.pbxproj
+++ b/Static.xcodeproj/project.pbxproj
@@ -27,8 +27,9 @@
 		36748D5C1B5034EC0046F207 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 36748D5A1B5034EC0046F207 /* LaunchScreen.storyboard */; };
 		36799F991B41C857009A9D16 /* CellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36799F981B41C857009A9D16 /* CellType.swift */; };
 		36C8FE9B1B4EECF30004DA5B /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C8FE9A1B4EECF30004DA5B /* TableViewController.swift */; };
+		39DC804A1BD96BB0001F04CD /* NibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DC80491BD96BB0001F04CD /* NibTableViewCell.swift */; };
 		A706253D1BC81C1400E471EF /* CustomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A706253B1BC81C1400E471EF /* CustomTableViewCell.swift */; };
-		A706253E1BC81C1400E471EF /* CustomTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A706253C1BC81C1400E471EF /* CustomTableViewCell.xib */; };
+		A706253E1BC81C1400E471EF /* NibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A706253C1BC81C1400E471EF /* NibTableViewCell.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,8 +87,9 @@
 		36748D5D1B5034EC0046F207 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		36799F981B41C857009A9D16 /* CellType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellType.swift; sourceTree = "<group>"; };
 		36C8FE9A1B4EECF30004DA5B /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+		39DC80491BD96BB0001F04CD /* NibTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibTableViewCell.swift; sourceTree = "<group>"; };
 		A706253B1BC81C1400E471EF /* CustomTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTableViewCell.swift; sourceTree = "<group>"; };
-		A706253C1BC81C1400E471EF /* CustomTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomTableViewCell.xib; sourceTree = "<group>"; };
+		A706253C1BC81C1400E471EF /* NibTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,7 +185,8 @@
 				36748D5A1B5034EC0046F207 /* LaunchScreen.storyboard */,
 				36748D5D1B5034EC0046F207 /* Info.plist */,
 				A706253B1BC81C1400E471EF /* CustomTableViewCell.swift */,
-				A706253C1BC81C1400E471EF /* CustomTableViewCell.xib */,
+				A706253C1BC81C1400E471EF /* NibTableViewCell.xib */,
+				39DC80491BD96BB0001F04CD /* NibTableViewCell.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -319,7 +322,7 @@
 			files = (
 				36748D5C1B5034EC0046F207 /* LaunchScreen.storyboard in Resources */,
 				36748D591B5034EC0046F207 /* Assets.xcassets in Resources */,
-				A706253E1BC81C1400E471EF /* CustomTableViewCell.xib in Resources */,
+				A706253E1BC81C1400E471EF /* NibTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -357,6 +360,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A706253D1BC81C1400E471EF /* CustomTableViewCell.swift in Sources */,
+				39DC804A1BD96BB0001F04CD /* NibTableViewCell.swift in Sources */,
 				36748D541B5034EC0046F207 /* ViewController.swift in Sources */,
 				36748D521B5034EC0046F207 /* WindowController.swift in Sources */,
 			);

--- a/Static/CellType.swift
+++ b/Static/CellType.swift
@@ -2,9 +2,16 @@ import UIKit
 
 public protocol CellType: class {
     static func description() -> String
+    static func nib() -> UINib?
+
     func configure(row row: Row)
 }
 
+extension CellType {
+    public static func nib() -> UINib? {
+        return nil
+    }
+}
 
 extension CellType where Self: UITableViewCell {
     public func configure(row row: Row) {

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -157,10 +157,9 @@ public class DataSource: NSObject {
             }
 
             registeredCellIdentifiers.insert(identifier)
-            if let nib = row.cellNib {
+            if let nib = row.cellClass.nib() {
                 tableView.registerNib(nib, forCellReuseIdentifier: identifier)
-            }
-            else {
+            } else {
                 tableView.registerClass(row.cellClass, forCellReuseIdentifier: identifier)
             }
         }
@@ -188,11 +187,11 @@ extension DataSource: UITableViewDataSource {
     }
 
     public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return rowForIndexPath(indexPath)?.height ?? 44
+        return rowForIndexPath(indexPath)?.height ?? UITableViewAutomaticDimension
     }
     
     public func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return rowForIndexPath(indexPath)?.height ?? 44
+        return rowForIndexPath(indexPath)?.height ?? UITableViewAutomaticDimension
     }
     
     public func numberOfSectionsInTableView(tableView: UITableView) -> Int {

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -111,12 +111,9 @@ public struct Row: Hashable, Equatable {
     /// View to be used for the row.
     public var cellClass: CellType.Type
 
-    /// Nib to be used for the row
-    public var cellNib: UINib?
-    
-    /// Row height
-    public var height: CGFloat?
-    
+    /// The row's height. Defaults to `UITableViewAutomaticDimension`.
+    public var height: CGFloat
+
     /// Additional information for the row.
     public var context: Context?
     
@@ -143,12 +140,8 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, cellNib: UINib? = nil, height: CGFloat? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
+        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat = UITableViewAutomaticDimension, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
         
-        if let _ = cellNib where cellClass == nil {
-            assert(false, "Specifying a cell Nib requires specifying a custom cell Class too")
-        }
-
         self.UUID = UUID
         self.text = text
         self.detailText = detailText
@@ -157,7 +150,6 @@ public struct Row: Hashable, Equatable {
         self.imageTintColor = imageTintColor
         self.accessory = accessory
         self.cellClass = cellClass ?? Value1Cell.self
-        self.cellNib = cellNib
         self.height = height
         self.context = context
         self.editActions = editActions


### PR DESCRIPTION
Providing an interface builder for a cell is a view concern and is
provided by a `UITableViewCell` subclass that conforms to `CellType`
and implements the `nib()` method.

* Remove `cellNib` from `Row`.
* Make `height` non-optional and default to
`UITableViewAutomaticDimension`.
* Add `nib() -> UINib?` method to `CellType`.