### PR TITLE
Support row heights set via `UITableView.rowHeight`

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -25,6 +25,8 @@ class ViewController: TableViewController {
         super.viewDidLoad()
 
         title = "Static"
+        
+        tableView.rowHeight = 66
 
         dataSource.sections = [
             Section(header: "Styles", rows: [
@@ -36,8 +38,8 @@ class ViewController: TableViewController {
                 Row(text: "Button", detailText: "Detail", cellClass: ButtonCell.self, selection: { [unowned self] in
                     self.showAlert(title: "Row Selection")
                 }),
-                Row(text: "Custom cell with explicit height", cellClass: CustomTableViewCell.self, height: 64),
-                Row(text: "Custom from nib", cellClass: NibTableViewCell.self)
+                Row(text: "Custom cell with explicit height", cellClass: CustomTableViewCell.self, height: 44),
+                Row(text: "Custom from nib", cellClass: NibTableViewCell.self, height: UITableViewAutomaticDimension)
             ], footer: "This is a section footer."),
             Section(header: "Accessories", rows: [
                 Row(text: "None"),

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -187,17 +187,19 @@ extension DataSource: UITableViewDataSource {
     }
 
     public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return rowForIndexPath(indexPath)?.height ?? UITableViewAutomaticDimension
+        guard let height = rowForIndexPath(indexPath)?.height else {
+            return tableView.rowHeight
+        }
+        
+        return height
     }
     
     public func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        guard let row = rowForIndexPath(indexPath) else { return UITableViewAutomaticDimension }
-
-        if row.height == UITableViewAutomaticDimension {
-            return 44
+        guard let height = rowForIndexPath(indexPath)?.height else {
+            return UITableViewAutomaticDimension
         }
 
-        return row.height
+        return height
     }
     
     public func numberOfSectionsInTableView(tableView: UITableView) -> Int {

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -111,8 +111,8 @@ public struct Row: Hashable, Equatable {
     /// View to be used for the row.
     public var cellClass: CellType.Type
 
-    /// The row's height. Defaults to `UITableViewAutomaticDimension`.
-    public var height: CGFloat
+    /// The row's height.
+    public var height: CGFloat?
 
     /// Additional information for the row.
     public var context: Context?
@@ -140,7 +140,7 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat = UITableViewAutomaticDimension, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
+        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
         
         self.UUID = UUID
         self.text = text


### PR DESCRIPTION
* Make `Row.height` optional and default to nil in the initializer
* When implementing `tableView(_: heightForRowAtIndexPath:)`, check if height is nil. If it's not, return it. If it is nil, return `tableView.rowHeight`.

This change requires that you opt into to autosizing by passing `UITableViewAutomaticDimension` for the height parameter in the `Row` initializer.