### PR TITLE
Ability to use UIGestureRecognizer for table cells

### DIFF
--- a/Static/CellType.swift
+++ b/Static/CellType.swift
@@ -24,5 +24,9 @@ extension CellType where Self: UITableViewCell {
         if let tintColor = row.imageTintColor {
             imageView?.tintColor = tintColor
         }
+        
+        if let gestureRecognizer = row.gestureRecognizer {
+            self.addGestureRecognizer(gestureRecognizer)
+        }
     }
 }

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -119,6 +119,9 @@ public struct Row: Hashable, Equatable {
     
     /// Actions to show when swiping the cell, such as Delete.
     public var editActions: [EditAction]
+    
+    /// Gesture recognizer for the cell
+    public var gestureRecognizer: UIGestureRecognizer?
 
     var canEdit: Bool {
         return editActions.count > 0
@@ -140,7 +143,7 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
+        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString, gestureRecognizer: UIGestureRecognizer? = nil) {
         
         self.UUID = UUID
         self.text = text
@@ -153,6 +156,7 @@ public struct Row: Hashable, Equatable {
         self.height = height
         self.context = context
         self.editActions = editActions
+        self.gestureRecognizer = gestureRecognizer;
     }
 }
 


### PR DESCRIPTION
The implementation is eventually not fully baked, but I like the idea to have an UIGestureRecognizer to create own swipe possibilities for the table cells. I would appreciate to have such an option in the static framework. What do you think about?
E.g.
![Image of TableView](http://cdn3.raywenderlich.com/wp-content/uploads/2014/07/Cues250.gif)