### PR TITLE
Make Row be agnostic of its presentation

### DIFF
--- a/Example/NibTableViewCell.xib
+++ b/Example/NibTableViewCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,7 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="104"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="103.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Kr-e3-EF9">
@@ -25,8 +24,7 @@
                 <animations/>
                 <constraints>
                     <constraint firstItem="0Kr-e3-EF9" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="0DV-UL-ORw"/>
-                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="33" id="S1U-RN-9XC"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="0Kr-e3-EF9" secondAttribute="bottom" constant="33" id="sGI-dG-GYf"/>
+                    <constraint firstItem="0Kr-e3-EF9" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Ejd-1V-inO"/>
                 </constraints>
             </tableViewCellContentView>
             <animations/>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -38,8 +38,7 @@ class ViewController: TableViewController {
                 Row(text: "Button", detailText: "Detail", cellClass: ButtonCell.self, selection: { [unowned self] in
                     self.showAlert(title: "Row Selection")
                 }),
-                Row(text: "Custom cell with explicit height", cellClass: CustomTableViewCell.self, height: 44),
-                Row(text: "Custom from nib", cellClass: NibTableViewCell.self, height: UITableViewAutomaticDimension)
+                Row(text: "Custom from nib", cellClass: NibTableViewCell.self)
             ], footer: "This is a section footer."),
             Section(header: "Accessories", rows: [
                 Row(text: "None"),

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: TableViewController {
 
         title = "Static"
         
-        tableView.rowHeight = 66
+        tableView.rowHeight = 50
 
         dataSource.sections = [
             Section(header: "Styles", rows: [

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -32,7 +32,6 @@ class ViewController: TableViewController {
             Section(header: "Styles", rows: [
                 Row(text: "Value 1", detailText: "Detail", cellClass: Value1Cell.self),
                 Row(text: "Value 1", detailText: "with an image", cellClass: Value1Cell.self, image: UIImage(named: "Settings")),
-                Row(text: "Value 1", detailText: "with a green tinted image", cellClass: Value1Cell.self, image: UIImage(named: "Settings"), imageTintColor: UIColor.greenColor()),
                 Row(text: "Value 2", detailText: "Detail", cellClass: Value2Cell.self),
                 Row(text: "Subtitle", detailText: "Detail", cellClass: SubtitleCell.self),
                 Row(text: "Button", detailText: "Detail", cellClass: ButtonCell.self, selection: { [unowned self] in

--- a/Static/CellType.swift
+++ b/Static/CellType.swift
@@ -20,9 +20,5 @@ extension CellType where Self: UITableViewCell {
         imageView?.image = row.image
         accessoryType = row.accessory.type
         accessoryView = row.accessory.view
-
-        if let tintColor = row.imageTintColor {
-            imageView?.tintColor = tintColor
-        }
     }
 }

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -186,22 +186,6 @@ extension DataSource: UITableViewDataSource {
         return UITableViewCell()
     }
 
-    public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        guard let height = rowForIndexPath(indexPath)?.height else {
-            return tableView.rowHeight
-        }
-        
-        return height
-    }
-    
-    public func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        guard let height = rowForIndexPath(indexPath)?.height else {
-            return UITableViewAutomaticDimension
-        }
-
-        return height
-    }
-    
     public func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return sections.count
     }

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -102,9 +102,6 @@ public struct Row: Hashable, Equatable {
     /// Image for the row
     public var image: UIImage?
 
-    /// Image tint color
-    public var imageTintColor: UIColor?
-
     /// Action to run when the row is selected.
     public var selection: Selection?
 
@@ -137,14 +134,13 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
+        image: UIImage? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
         
         self.UUID = UUID
         self.text = text
         self.detailText = detailText
         self.selection = selection
         self.image = image
-        self.imageTintColor = imageTintColor
         self.accessory = accessory
         self.cellClass = cellClass ?? Value1Cell.self
         self.context = context

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -111,9 +111,6 @@ public struct Row: Hashable, Equatable {
     /// View to be used for the row.
     public var cellClass: CellType.Type
 
-    /// The row's height.
-    public var height: CGFloat?
-
     /// Additional information for the row.
     public var context: Context?
     
@@ -140,7 +137,7 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, height: CGFloat? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
+        image: UIImage? = nil, imageTintColor: UIColor? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
         
         self.UUID = UUID
         self.text = text
@@ -150,7 +147,6 @@ public struct Row: Hashable, Equatable {
         self.imageTintColor = imageTintColor
         self.accessory = accessory
         self.cellClass = cellClass ?? Value1Cell.self
-        self.height = height
         self.context = context
         self.editActions = editActions
     }

--- a/Static/Tests/RowTests.swift
+++ b/Static/Tests/RowTests.swift
@@ -22,13 +22,6 @@ class RowTests: XCTestCase {
         XCTAssertEqual(row.image, image)
     }
 
-    func testInitWithImageTintColor() {
-        let image = UIImage(named: "Setting")
-        let row = Row(image: image, imageTintColor: UIColor.lightGrayColor())
-        XCTAssertEqual(row.image, image)
-        XCTAssertEqual(row.imageTintColor, UIColor.lightGrayColor())
-    }
-
     func testInitWithAccessoryType() {
         let accessory: Row.Accessory = .Checkmark
 


### PR DESCRIPTION
Row shouldn't know anything about how its displayed (with the exception of specifying a class to display it). This was the original design of Static. I'm proposing going back to that mindset with a few small changes.

#### Remove Height

If you want a custom height for a cell, set `tableView.estimatedRowHeight` and then add a constraint to `cell.contentView` to set its height. This is a much more flexible way to go about custom heights if you need varying heights in the same table view.

#### Remove Image Tint Color

From the very beginning, you couldn't set a label's color. This was by design. If you wanted to change the presentation of a label, you had to make a custom cell. I think this same thinking applies to images. If you want to set the color of an image, either do it before it gets to the Row or do it in the cell. Having the Row tell the cell what color it is violates its lack of understanding of presentation.

---

I tried to explain my reasoning. Hopefully this doesn't seem silly. It's awesome to see people contributing to Static, but I think these two additions are going the wrong direction. Thoughts? :heart: