### PR TITLE
Simpler TableViewController

### DIFF
--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -1,17 +1,10 @@
 import UIKit
 
-/// Table view controller with a `DataSource` setup to use its `tableView`.
-public class TableViewController: UIViewController {
+/// Table view controller with a `DataSource` setup to use its `tableView`. The view controller's
+/// `UITableViewDataSource` and `UITableViewDelegate` methods will not be called.
+public class TableViewController: UITableViewController {
 
     // MARK: - Properties
-
-    /// Returns the table view managed by the controller object.
-    public let tableView: UITableView
-
-    /// A Boolean value indicating if the controller clears the selection when the table appears.
-    ///
-    /// The default value of this property is YES. When YES, the table view controller clears the table’s current selection when it receives a viewWillAppear: message. Setting this property to NO preserves the selection.
-    public var clearsSelectionOnViewWillAppear: Bool = true
 
     /// Table view data source.
     public var dataSource = DataSource() {
@@ -27,62 +20,40 @@ public class TableViewController: UIViewController {
 
     // MARK: - Initialization
 
-    public init(style: UITableViewStyle) {
-        tableView = UITableView(frame: .zero, style: style)
-        super.init(nibName: nil, bundle: nil)
-        dataSource.tableView = tableView
+    public override init(style: UITableViewStyle) {
+        super.init(style: style)
+        initialize()
     }
 
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
-        tableView = UITableView(frame: .zero, style: .Plain)
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        dataSource.tableView = tableView
+        initialize()
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    public convenience init() {
-        self.init(style: .Plain)
+        super.init(coder: aDecoder)
+        initialize()
     }
 
 
     // MARK: - UIViewController
 
-    public override func loadView() {
-        tableView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        view = tableView
-    }
-
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         performInitialLoad()
-        clearSelectionsIfNecessary()
-    }
-
-    public override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        tableView.flashScrollIndicators()
-    }
-
-    public override func setEditing(editing: Bool, animated: Bool) {
-        super.setEditing(editing, animated: animated)
-        tableView.setEditing(editing, animated: animated)
     }
 
 
     // MARK: - Private
+
+    private func initialize() {
+        dataSource.tableView = tableView
+    }
 
     private var initialLoadOnceToken = dispatch_once_t()
     private func performInitialLoad() {
         dispatch_once(&initialLoadOnceToken) {
             self.tableView.reloadData()
         }
-    }
-
-    private func clearSelectionsIfNecessary() {
-        guard clearsSelectionOnViewWillAppear else { return }
-        tableView.indexPathsForSelectedRows?.forEach { tableView.deselectRowAtIndexPath($0, animated: true) }
     }
 }

--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -18,42 +18,10 @@ public class TableViewController: UITableViewController {
     }
 
 
-    // MARK: - Initialization
-
-    public override init(style: UITableViewStyle) {
-        super.init(style: style)
-        initialize()
-    }
-
-    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        initialize()
-    }
-
-    public required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        initialize()
-    }
-
-
     // MARK: - UIViewController
 
-    public override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        performInitialLoad()
-    }
-
-
-    // MARK: - Private
-
-    private func initialize() {
+    public override func viewDidLoad() {
+        super.viewDidLoad()
         dataSource.tableView = tableView
-    }
-
-    private var initialLoadOnceToken = dispatch_once_t()
-    private func performInitialLoad() {
-        dispatch_once(&initialLoadOnceToken) {
-            self.tableView.reloadData()
-        }
     }
 }


### PR DESCRIPTION
Converted to use plain `UITableViewController` instead of rolling our own. I totally get the value of using a plain `UIViewController` with its table view as a subview of `view`, but that's not a decision Static should be making for its consumers in my opinion. I think the system default should be Static's default, and if you want something custom, you're welcome to customize it.
