### PR TITLE
Handle selection clearing properly during interactive presentations

### DIFF
--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -58,7 +58,7 @@ public class TableViewController: UIViewController {
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         performInitialLoad()
-        clearSelectionsIfNecessary()
+        clearSelectionsIfNecessary(animated)
     }
 
     public override func viewDidAppear(animated: Bool) {
@@ -81,8 +81,31 @@ public class TableViewController: UIViewController {
         }
     }
 
-    private func clearSelectionsIfNecessary() {
-        guard clearsSelectionOnViewWillAppear else { return }
-        tableView.indexPathsForSelectedRows?.forEach { tableView.deselectRowAtIndexPath($0, animated: true) }
+    private func clearSelectionsIfNecessary(animated: Bool) {
+        guard let selectedIndexPaths = tableView.indexPathsForSelectedRows where clearsSelectionOnViewWillAppear else { return }
+        guard let coordinator = transitionCoordinator() else {
+            deselectRowsAtIndexPaths(selectedIndexPaths, animated: animated)
+            return
+        }
+
+        let animation: UIViewControllerTransitionCoordinatorContext -> Void = { [weak self] _ in
+            self?.deselectRowsAtIndexPaths(selectedIndexPaths, animated: animated)
+        }
+
+        let completion: UIViewControllerTransitionCoordinatorContext -> Void = { [weak self] context in
+            if context.isCancelled() {
+                self?.selectRowsAtIndexPaths(selectedIndexPaths, animated: animated)
+            }
+        }
+
+        coordinator.animateAlongsideTransition(animation, completion: completion)
+    }
+
+    private func selectRowsAtIndexPaths(indexPaths: [NSIndexPath], animated: Bool) {
+        indexPaths.forEach { tableView.selectRowAtIndexPath($0, animated: animated, scrollPosition: .None) }
+    }
+
+    private func deselectRowsAtIndexPaths(indexPaths: [NSIndexPath], animated: Bool) {
+        indexPaths.forEach { tableView.deselectRowAtIndexPath($0, animated: animated) }
     }
 }

--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -10,7 +10,7 @@ public class TableViewController: UIViewController {
 
     /// A Boolean value indicating if the controller clears the selection when the table appears.
     ///
-    /// The default value of this property is YES. When YES, the table view controller clears the table’s current selection when it receives a viewWillAppear: message. Setting this property to NO preserves the selection.
+    /// The default value of this property is true. When true, the table view controller clears the table’s current selection when it receives a viewWillAppear: message. Setting this property to false preserves the selection.
     public var clearsSelectionOnViewWillAppear: Bool = true
 
     /// Table view data source.


### PR DESCRIPTION
Fixes #50.

This updates `TableViewController` to use `UIViewController`'s `transitionCoordinator` in `viewWillAppear` to determine if an interactive transition was canceled and handles row selections and deselections appropriately. Hat tip to @calebd for the implementation idea.

The fix won't actually be evident until we do something about https://github.com/venmo/Static/issues/65, however.