### PR TITLE
Add option to disable automatically deselecting rows on selection

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -40,6 +40,9 @@ public class DataSource: NSObject {
         }
     }
 
+    /// Automatically deselect rows after they are selected
+    public var automaticallyDeselectRows = true
+
     private var registeredCellIdentifiers = Set<String>()
 
 
@@ -262,7 +265,9 @@ extension DataSource: UITableViewDelegate {
     }
 
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        tableView.deselectRowAtIndexPath(indexPath, animated: true)
+        if automaticallyDeselectRows {
+            tableView.deselectRowAtIndexPath(indexPath, animated: true)
+        }
 
         if let row = rowForIndexPath(indexPath) {
             row.selection?()


### PR DESCRIPTION
Added this and turned it on to fix flashes when navigating. This doesn't change the current behavior. Just gives you an option to turn it off.