### PR TITLE
Making IBOutlet private

### DIFF
--- a/Example/NibTableViewCell.swift
+++ b/Example/NibTableViewCell.swift
@@ -5,7 +5,7 @@ final class NibTableViewCell: UITableViewCell, CellType {
 
     // MARK: - Properties
 
-    @IBOutlet weak var centeredLabel: UILabel!
+    @IBOutlet weak private var centeredLabel: UILabel!
 
     
     // MARK: - CellType


### PR DESCRIPTION
I think we should not expose `centeredLabel` and let `func configure(row row: Row)`  do the job.