### PR TITLE
Using flatMap instead of map+reduce

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -144,9 +144,7 @@ public class DataSource: NSObject {
         guard let tableView = tableView else { return }
 
         // Filter to only rows with unregistered cells
-        let rows = sections.map({ $0.rows }).reduce([], combine: +).filter() {
-            !self.registeredCellIdentifiers.contains($0.cellIdentifier)
-        }
+        let rows = sections.flatMap{ $0.rows }.filter { !self.registeredCellIdentifiers.contains($0.cellIdentifier) }
 
         for row in rows {
             let identifier = row.cellIdentifier


### PR DESCRIPTION
I think this code refactoring is bit cleaner. 

Also apart from proposed code refactoring i am wondering why following block of code is added in this `refreshRegisteredCells` function.
``` Swift
            // Check again in case there were duplicate new cell classes
            if registeredCellIdentifiers.contains(identifier) {
                continue
            }
```

are we not convinced that  following piece of code will do its job?

``` Swift
        // Filter to only rows with unregistered cells
        let rows = sections.map({ $0.rows }).reduce([], combine: +).filter() {
            !self.registeredCellIdentifiers.contains($0.cellIdentifier)
        }
```

I think following implementation is sufficient

``` Swift
    private func refreshRegisteredCells() {
        // A table view is required to manipulate registered cells
        guard let tableView = tableView else { return }

        // Filter to only rows with unregistered cells
        let rows = sections.flatMap{ $0.rows }.filter { !self.registeredCellIdentifiers.contains($0.cellIdentifier) }

        for row in rows {
            let identifier = row.cellIdentifier
            registeredCellIdentifiers.insert(identifier)
            if let nib = row.cellClass.nib() {
                tableView.registerNib(nib, forCellReuseIdentifier: identifier)
            } else {
                tableView.registerClass(row.cellClass, forCellReuseIdentifier: identifier)
            }
        }
    }
```

Am i missing something here?
