### PR TITLE
Add support to use storyboard cell prototype as cell

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -160,7 +160,8 @@ public class DataSource: NSObject {
             registeredCellIdentifiers.insert(identifier)
             if let nib = row.cellClass.nib() {
                 tableView.registerNib(nib, forCellReuseIdentifier: identifier)
-            } else {
+            } else if row.storyboardCellIdentifier == nil {
+            // Only register when we are not using storyboard cell identifier. Registering will cause the prototype cell not to be loaded and assume that we are using custom class
                 tableView.registerClass(row.cellClass, forCellReuseIdentifier: identifier)
             }
         }

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -113,6 +113,9 @@ public struct Row: Hashable, Equatable {
     
     /// Actions to show when swiping the cell, such as Delete.
     public var editActions: [EditAction]
+    
+    /// Cell identifier from storyboard
+    public var storyboardCellIdentifier: String?
 
     var canEdit: Bool {
         return editActions.count > 0
@@ -123,7 +126,8 @@ public struct Row: Hashable, Equatable {
     }
 
     var cellIdentifier: String {
-        return cellClass.description()
+        // Storyboard cell identifier have precedence
+        return storyboardCellIdentifier ?? cellClass.description()
     }
 
     public var hashValue: Int {
@@ -134,8 +138,8 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString) {
-        
+        image: UIImage? = nil, accessory: Accessory = .None, cellClass: CellType.Type? = nil, storyboardCellIdentifier: String? = nil, context: Context? = nil, editActions: [EditAction] = [], UUID: String = NSUUID().UUIDString, backgroundColor: UIColor? = nil) {
+            
         self.UUID = UUID
         self.text = text
         self.detailText = detailText
@@ -145,6 +149,7 @@ public struct Row: Hashable, Equatable {
         self.cellClass = cellClass ?? Value1Cell.self
         self.context = context
         self.editActions = editActions
+        self.storyboardCellIdentifier = storyboardCellIdentifier
     }
 }
 


### PR DESCRIPTION
This change will allow developer to specify a storyboard cell identifier to be used for dequeueReusableCellWithIdentifier.