### PR TITLE
Flip `initiallyLoaded` sentinel to true during initial load

### DIFF
--- a/Static/TableViewController.swift
+++ b/Static/TableViewController.swift
@@ -78,6 +78,7 @@ open class TableViewController: UIViewController {
     private func performInitialLoad() {
         if !initiallyLoaded {
             tableView.reloadData()
+            initiallyLoaded = true
         }
     }
 


### PR DESCRIPTION
Fixes a regression from 3e691f5 which replaced the deprecated `dispatch_once` with a sentinel value.