### PR TITLE
Migrate unit tests to Swift 3

### DIFF
--- a/Static.xcodeproj/project.pbxproj
+++ b/Static.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 					};
 					21826AB31B3F51A100AA9641 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 					};
 					36748D4E1B5034EC0046F207 = {
 						CreatedOnToolsVersion = 7.0;
@@ -537,7 +538,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.static.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -549,7 +550,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.static.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -199,11 +199,11 @@ extension DataSource: UITableViewDataSource {
         return section(at: sectionIndex)?.header?._title
     }
 
-    public func tableView(tableView: UITableView, viewForHeaderInSection sectionIndex: Int) -> UIView? {
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection sectionIndex: Int) -> UIView? {
         return section(at: sectionIndex)?.header?._view
     }
 
-    public func tableView(tableView: UITableView, heightForHeaderInSection sectionIndex: Int) -> CGFloat {
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection sectionIndex: Int) -> CGFloat {
         return section(at: sectionIndex)?.header?.viewHeight ?? UITableViewAutomaticDimension
     }
 
@@ -211,11 +211,11 @@ extension DataSource: UITableViewDataSource {
         return section(at: sectionIndex)?.footer?._title
     }
 
-    public func tableView(tableView: UITableView, viewForFooterInSection sectionIndex: Int) -> UIView? {
+    public func tableView(_ tableView: UITableView, viewForFooterInSection sectionIndex: Int) -> UIView? {
         return section(at: sectionIndex)?.footer?._view
     }
 
-    public func tableView(tableView: UITableView, heightForFooterInSection sectionIndex: Int) -> CGFloat {
+    public func tableView(_ tableView: UITableView, heightForFooterInSection sectionIndex: Int) -> CGFloat {
         return section(at: sectionIndex)?.footer?.viewHeight ?? UITableViewAutomaticDimension
     }
 

--- a/Static/Tests/DataSourceTests.swift
+++ b/Static/Tests/DataSourceTests.swift
@@ -28,8 +28,8 @@ class DataSourceTests: XCTestCase {
             Section(rows: [Row(text: "Row"), Row(text: "Row")])
         ]
         XCTAssertEqual(2, tableView.numberOfSections)
-        XCTAssertEqual(1, tableView.numberOfRowsInSection(0))
-        XCTAssertEqual(2, tableView.numberOfRowsInSection(1))
+        XCTAssertEqual(1, tableView.numberOfRows(inSection: 0))
+        XCTAssertEqual(2, tableView.numberOfRows(inSection: 1))
 
         dataSource.sections = [
             Section(rows: [Row(text: "Your"), Row(text: "Boat")]),
@@ -37,9 +37,9 @@ class DataSourceTests: XCTestCase {
             Section(rows: [Row(text: "Merrily"), Row(text: "Merrily")])
         ]
         XCTAssertEqual(3, tableView.numberOfSections)
-        XCTAssertEqual(2, tableView.numberOfRowsInSection(0))
-        XCTAssertEqual(4, tableView.numberOfRowsInSection(1))
-        XCTAssertEqual(2, tableView.numberOfRowsInSection(2))
+        XCTAssertEqual(2, tableView.numberOfRows(inSection: 0))
+        XCTAssertEqual(4, tableView.numberOfRows(inSection: 1))
+        XCTAssertEqual(2, tableView.numberOfRows(inSection: 2))
 
         dataSource.sections = []
         XCTAssertEqual(0, tableView.numberOfSections)
@@ -48,13 +48,13 @@ class DataSourceTests: XCTestCase {
     func testCellForRowAtIndexPath() {
         dataSource.sections = [
             Section(rows: [
-                Row(text: "Merrily", detailText: "merrily", accessory: .DisclosureIndicator)
+                Row(text: "Merrily", detailText: "merrily", accessory: .disclosureIndicator)
             ])
         ]
-        let cell = tableView.cellForRowAtIndexPath(IndexPath(forRow: 0, inSection: 0))!
+        let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 0))!
         XCTAssertEqual("Merrily", cell.textLabel!.text!)
         XCTAssertEqual("merrily", cell.detailTextLabel!.text!)
-        XCTAssertEqual(UITableViewCellAccessoryType.DisclosureIndicator, cell.accessoryType)
+        XCTAssertEqual(UITableViewCellAccessoryType.disclosureIndicator, cell.accessoryType)
     }
 
     func testExtremityTitles() {
@@ -74,7 +74,7 @@ class DataSourceTests: XCTestCase {
         let header = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 100))
         let footer = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 44))
         dataSource.sections = [
-            Section(header: .View(header), footer: .View(footer))
+            Section(header: .view(header), footer: .view(footer))
         ]
 
         XCTAssertEqual(header, dataSource.tableView(tableView, viewForHeaderInSection: 0)!)
@@ -87,16 +87,16 @@ class DataSourceTests: XCTestCase {
         dataSource.sections = [
             Section(rows: [Row(text: "Cookies")])
         ]
-        XCTAssertFalse(dataSource.tableView(tableView, shouldHighlightRowAtIndexPath: IndexPath(forRow: 0, inSection: 0)))
+        XCTAssertFalse(dataSource.tableView(tableView, shouldHighlightRowAt: IndexPath(row: 0, section: 0)))
 
         dataSource.sections = [
             Section(rows: [Row(text: "Cupcakes", selection: {})])
         ]
-        XCTAssertTrue(dataSource.tableView(tableView, shouldHighlightRowAtIndexPath: IndexPath(forRow: 0, inSection: 0)))
+        XCTAssertTrue(dataSource.tableView(tableView, shouldHighlightRowAt: IndexPath(row: 0, section: 0)))
     }
 
     func testSelection() {
-        let expectation = expectationWithDescription("Selected")
+        let expectation = self.expectation(description: "Selected")
         let selection = {
             expectation.fulfill()
         }
@@ -104,24 +104,24 @@ class DataSourceTests: XCTestCase {
         dataSource.sections = [
             Section(rows: [Row(text: "Button", selection: selection)])
         ]
-        dataSource.tableView(tableView, didSelectRowAtIndexPath: IndexPath(forRow: 0, inSection: 0))
-        waitForExpectationsWithTimeout(1, handler: nil)
+        dataSource.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testAccessorySelection() {
-        let expectation = expectationWithDescription("Accessory Selected")
+        let expectation = self.expectation(description: "Accessory Selected")
         let selection = {
             expectation.fulfill()
         }
 
-        let accessory = Row.Accessory.DetailButton(selection)
+        let accessory = Row.Accessory.detailButton(selection)
 
         dataSource.sections = [
             Section(rows: [Row(text: "Banana Cream Pie", accessory: accessory)])
         ]
 
-        dataSource.tableView(tableView, accessoryButtonTappedForRowWithIndexPath: IndexPath(forRow: 0, inSection: 0))
-        waitForExpectationsWithTimeout(1, handler: nil)
+        dataSource.tableView(tableView, accessoryButtonTappedForRowWith: IndexPath(row: 0, section: 0))
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testChangeTableView() {

--- a/Static/Tests/RowTests.swift
+++ b/Static/Tests/RowTests.swift
@@ -9,8 +9,8 @@ class RowTests: XCTestCase {
             "Hello": "world"
         ]
 
-        let row = Row(text: "Title", detailText: "Detail", selection: selection, cellClass: ButtonCell.self, context: context, UUID: "1234")
-        XCTAssertEqual("1234", row.UUID)
+        let row = Row(text: "Title", detailText: "Detail", selection: selection, cellClass: ButtonCell.self, context: context, uuid: "1234")
+        XCTAssertEqual("1234", row.uuid)
         XCTAssertEqual("Title", row.text!)
         XCTAssertEqual("Detail", row.detailText!)
         XCTAssertEqual("world", row.context?["Hello"] as? String)
@@ -23,7 +23,7 @@ class RowTests: XCTestCase {
     }
 
     func testInitWithAccessoryType() {
-        let accessory: Row.Accessory = .Checkmark
+        let accessory: Row.Accessory = .checkmark
 
         let row = Row(accessory: accessory)
 
@@ -32,7 +32,7 @@ class RowTests: XCTestCase {
 
     func testInitWithSelectableAccessoryType() {
         let selection: Selection = {}
-        let accessory: Row.Accessory = .DetailButton(selection)
+        let accessory: Row.Accessory = .detailButton(selection)
 
         let row = Row(accessory: accessory)
 
@@ -42,7 +42,7 @@ class RowTests: XCTestCase {
 
     func testInitWithAccessoryView() {
         let view = UIView()
-        let accessory: Row.Accessory = .View(view)
+        let accessory: Row.Accessory = .view(view)
 
         let row = Row(accessory: accessory)
 

--- a/Static/Tests/SectionTests.swift
+++ b/Static/Tests/SectionTests.swift
@@ -1,23 +1,23 @@
 import XCTest
-import Static
+@testable import Static
 
 class SectionTests: XCTestCase {
 
     func testInit() {
         let rows = [Row(text: "Row")]
-        let section = Section(UUID: "1234", header: "Header", rows: rows, footer: "Footer")
-        XCTAssertEqual("1234", section.UUID)
-        XCTAssertEqual("Header", section.header!.title!)
+        let section = Section(header: "Header", rows: rows, footer: "Footer", uuid: "1234")
+        XCTAssertEqual("1234", section.uuid)
+        XCTAssertEqual("Header", section.header!._title!)
         XCTAssertEqual(rows, section.rows)
-        XCTAssertEqual("Footer", section.footer!.title!)
+        XCTAssertEqual("Footer", section.footer!._title!)
     }
 
     func testExtermityViews() {
         let header = UIView()
         let footer = UIView()
-        let section = Section(header: .View(header), footer: .View(footer))
-        XCTAssertEqual(header, section.header!.view!)
-        XCTAssertEqual(footer, section.footer!.view!)
+        let section = Section(header: .view(header), footer: .view(footer))
+        XCTAssertEqual(header, section.header!._view!)
+        XCTAssertEqual(footer, section.footer!._view!)
     }
 
     func testHashable() {


### PR DESCRIPTION
* Updates method signatures of some `UITableViewDataSource` and `UITableViewDelegate` to match their Swift 3 variants.
* Adds `@testable` to Static import in SectionTests.swift so that the newly `internal` properties, `_title` and `_view` are accessible.
* Makes The Unit Tests Great Again™