### PR TITLE
add possibility to react on will display header and footer

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -42,7 +42,11 @@ public class DataSource: NSObject {
 
     /// Automatically deselect rows after they are selected
     public var automaticallyDeselectRows = true
+    
+    public var willDisplayHeader: ((UIView, Int) -> Void)? = nil
 
+    public var willDisplayFooter: ((UIView, Int) -> Void)? = nil
+    
     private var registeredCellIdentifiers = Set<String>()
 
 
@@ -219,6 +223,14 @@ extension DataSource: UITableViewDataSource {
         return section(at: sectionIndex)?.footer?.viewHeight ?? UITableViewAutomaticDimension
     }
 
+    public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        willDisplayHeader?(view, section)
+    }
+    
+    public func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        willDisplayFooter?(view, section)
+    }
+    
     public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return row(at: indexPath)?.canEdit ?? false
     }


### PR DESCRIPTION
As reported in #78 I decided to make small PR with possibility to quickly access two methods of `UITableViewDelegate`:
- `tableView(_:, willDisplayHeaderView:, forSection:)`
- `tableView(_:, willDisplayFooterView:, forSection:)`

The reason we need to have the simplest possibility to access those method is that `UIKit` somehow overrides header view appearance (for `UITableViewHeaderFooterVIew`) and those two methods can be used for configuring header/footer correctly.

The solution here is to provide two closures:
- `dataSource.willDisplayHeader: ((UIView, Int) -> Void)?`
- `dataSource.willDisplayFooter: ((UIView, Int) -> Void)?`

I wish we could have better architecture for that than just a properties with closures, but this solution fulfills two most important requirements:
- provides expected feature
- don't introduce any breaking change into `Static`