### PR TITLE
Allow a row to hold an associated object

### DIFF
--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -57,6 +57,8 @@ public struct Row: Hashable, Equatable {
         }
     }
 
+    public var associatedObject: Any?
+
     public typealias Context = [String: Any]
 
     /// Representation of an editing action, when swiping to edit a cell.


### PR DESCRIPTION
- This PR adds an `associatedObject` property to a row
- the associated object, allows adding any object to the row, which can later be used to layout a cell, that might not fit into the default paradigm, making `row` more versatile
- this allows continuing to use static for a tableView which would otherwise have to be converted to a more generic version 
- my use case specifically involves a static table where most of the cells are standard static cells, but one is a different (already implemented) cell. Using this change I can override the configure method of that cell (its conformance to `Cell`) to grab this associated object (which is essentially a view model), and lay itself out
