### PR TITLE
Fix display of empty headers on iOS 11

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -204,7 +204,7 @@ extension DataSource: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, heightForHeaderInSection sectionIndex: Int) -> CGFloat {
-        return section(at: sectionIndex)?.header?.viewHeight ?? UITableViewAutomaticDimension
+        return section(at: sectionIndex)?.header?.viewHeight ?? 0
     }
 
     public func tableView(_ tableView: UITableView, titleForFooterInSection sectionIndex: Int) -> String? {
@@ -216,7 +216,7 @@ extension DataSource: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, heightForFooterInSection sectionIndex: Int) -> CGFloat {
-        return section(at: sectionIndex)?.footer?.viewHeight ?? UITableViewAutomaticDimension
+        return section(at: sectionIndex)?.footer?.viewHeight ?? 0
     }
 
     public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {

--- a/Static/Section.swift
+++ b/Static/Section.swift
@@ -27,8 +27,11 @@ public struct Section: Hashable, Equatable {
             }
         }
 
-        var viewHeight: CGFloat? {
-            return _view?.bounds.height
+        var viewHeight: CGFloat {
+            switch self {
+            case .title: return UITableViewAutomaticDimension
+            case .view(let extremityView): return extremityView.bounds.height
+            }
         }
     }
 


### PR DESCRIPTION
Makes `viewHeight` on `Extremity` non-optional and nil-coalesces to a height of 0 for `nil` section extremities - fixes #105.
