### PR TITLE
Update podspec for version 2.0.2

### DIFF
--- a/Static.podspec
+++ b/Static.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Static'
-  spec.version = '2.0.1'
+  spec.version = '2.0.2'
   spec.summary = 'Simple static table views for iOS in Swift.'
   spec.description = 'Static provides simple static table views for iOS in Swift.'
   spec.homepage = 'https://github.com/venmo/static'


### PR DESCRIPTION
Updates the podspec to reflect the 2.0.2 release. It's been a while since I've pushed an update to a pod, does the maintainer need to run `trunk` or something as well? 