### PR TITLE
Add ability to receive UITableViewDelegate & UIScrollViewDelegate messages from UITableView

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -33,6 +33,7 @@ class ViewController: TableViewController {
         tableView.estimatedSectionHeaderHeight = 13.5
         tableView.estimatedSectionFooterHeight = 13.5
 
+        dataSource = DataSource(tableViewDelegate: self)
         dataSource.sections = [
             Section(header: "Styles", rows: [
                 Row(text: "Value 1", detailText: "Detail", cellClass: Value1Cell.self),
@@ -86,6 +87,25 @@ class ViewController: TableViewController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: button, style: .cancel, handler: nil))
         present(alert, animated: true, completion: nil)
+    }
+}
+
+extension TableViewController: UITableViewDelegate {
+    // MARK: - UIScrollViewDelegate example functions
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        // You can get UIScrollViewDelegate functions forwarded, even though the `DataSource` instance is the true delegate
+        // ...
+    }
+    
+    // MARK: - UITableViewDelegate example functions
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        // You can get UITableViewDelegate functions forwarded, even though the `DataSource` instance is the true delegate
+        // ...
+    }
+
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // The Row object's `selection` property will handle most of your use cases, but
+        // if you need to do something additional you can still implement this function.
     }
 }
 

--- a/Static.podspec
+++ b/Static.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Static'
-  spec.version = '2.2.0'
+  spec.version = '2.3.0'
   spec.summary = 'Simple static table views for iOS in Swift.'
   spec.description = 'Static provides simple static table views for iOS in Swift.'
   spec.homepage = 'https://github.com/venmo/static'

--- a/Static/Tests/DataSourceTests.swift
+++ b/Static/Tests/DataSourceTests.swift
@@ -138,4 +138,31 @@ class DataSourceTests: XCTestCase {
         XCTAssertEqual(dataSource, tableView2.dataSource as? DataSource)
         XCTAssertEqual(dataSource, tableView2.delegate as? DataSource)
     }
+
+    func testTableViewDelegateForwarding() {
+        // Sample object that conforms to `UITableViewDelegate` protocol
+        class TestTableViewDelegate: NSObject, UITableViewDelegate {
+            static var delegateDidForward = false
+
+            func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+                TestTableViewDelegate.delegateDidForward = true
+            }
+        }
+
+        let sampleDelegate = TestTableViewDelegate()
+        let dataSource2 = DataSource(tableViewDelegate: sampleDelegate)
+
+        XCTAssertNotNil(dataSource2.tableViewDelegate)
+
+        let forwardingTarget = dataSource2.forwardingTarget(for: #selector(UITableViewDelegate.tableView(_:willDisplay:forRowAt:)))
+        XCTAssertNotNil(forwardingTarget)
+        XCTAssertNotNil(forwardingTarget as? TestTableViewDelegate)
+
+        // Test actual message
+        TestTableViewDelegate.delegateDidForward = false
+
+        (dataSource2 as UITableViewDelegate).tableView!(UITableView(), willDisplay: UITableViewCell(), forRowAt: IndexPath())
+        XCTAssertTrue(TestTableViewDelegate.delegateDidForward)
+
+    }
 }


### PR DESCRIPTION
Using Static for your table view solutions previously caused some limitations for certain use cases. Since the `DataSource` object is both the `dataSource` & `delegate` of the `UITableView` instance, users of the Static library were unable to receive the `UITableViewDelegate` methods they might need to do things like reacting to scrolling, header displays or any further actions.

This change introduces a new `weak` property on `DataSource`: `tableViewDelegate`. This needs to be set during init, due to the execution timing of `forwardingTarget` & `respondsToSelector`. Using those two methods, the unimplemented `UITableViewDelegate` methods can get forwarded to the delegate that the user specifies, unlocking this missing functionality, mentioned in #97, #78, #72.

Two already implemented `UITableViewDelegate` functions will also forward the message to the `tableViewDelegate` property (if it implements those methods). The other remaining function's behavior is already fully exposed by Static, so it didn't need to be changed.

Other notes about this change/PR:
- This is backwards compatible. Updated version based on semantic versioning.
- Unit test added, fully covers new code.
- Example `ViewController` class modified to include example of this functionality.
