### PR TITLE
Add UISwitch accessory type

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -55,6 +55,9 @@ class ViewController: TableViewController {
                 Row(text: "Detail Button", accessory: .detailButton({ [unowned self] in
                     self.showAlert(title: "Detail Button")
                 })),
+                Row(text: "UISwitch", accessory: .switchToggle(value: false) { [unowned self] newValue in
+                    self.showAlert(title: "Switch Toggled: \(newValue ? "On" : "Off")")
+                }),
                 Row(text: "Custom View", accessory: .view(customAccessory))
             ], footer: "Try tapping the ⓘ buttons."),
             Section(header: "Selection", rows: [

--- a/Static.xcodeproj/project.pbxproj
+++ b/Static.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		39DC804A1BD96BB0001F04CD /* NibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DC80491BD96BB0001F04CD /* NibTableViewCell.swift */; };
 		A706253D1BC81C1400E471EF /* CustomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A706253B1BC81C1400E471EF /* CustomTableViewCell.swift */; };
 		A706253E1BC81C1400E471EF /* NibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A706253C1BC81C1400E471EF /* NibTableViewCell.xib */; };
+		B84E13F720555E26001D6C99 /* SwitchAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84E13F620555E26001D6C99 /* SwitchAccessory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		39DC80491BD96BB0001F04CD /* NibTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibTableViewCell.swift; sourceTree = "<group>"; };
 		A706253B1BC81C1400E471EF /* CustomTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomTableViewCell.swift; sourceTree = "<group>"; };
 		A706253C1BC81C1400E471EF /* NibTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibTableViewCell.xib; sourceTree = "<group>"; };
+		B84E13F620555E26001D6C99 /* SwitchAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchAccessory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +149,7 @@
 				36C8FE9A1B4EECF30004DA5B /* TableViewController.swift */,
 				21826AC61B3F51D000AA9641 /* Section.swift */,
 				21826AC51B3F51D000AA9641 /* Row.swift */,
+				B84E13F620555E26001D6C99 /* SwitchAccessory.swift */,
 				366AB2E91B4DFCDD002C4717 /* Cells */,
 				21826AAF1B3F51A100AA9641 /* Info.plist */,
 				366AB2ED1B4EE1A7002C4717 /* Tests */,
@@ -339,6 +342,7 @@
 			files = (
 				21F219631D10B7B9001EC0F5 /* SubtitleCell.swift in Sources */,
 				21F219611D10B7A9001EC0F5 /* Value1Cell.swift in Sources */,
+				B84E13F720555E26001D6C99 /* SwitchAccessory.swift in Sources */,
 				21826ACA1B3F51D000AA9641 /* Row.swift in Sources */,
 				21F219671D10B7CF001EC0F5 /* Section.swift in Sources */,
 				21F219621D10B7B9001EC0F5 /* Value2Cell.swift in Sources */,

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -2,6 +2,7 @@ import UIKit
 
 /// Row or Accessory selection callback.
 public typealias Selection = () -> Void
+public typealias ValueChange = (Bool) -> ()
 
 /// Representation of a table row.
 public struct Row: Hashable, Equatable {
@@ -24,6 +25,9 @@ public struct Row: Hashable, Equatable {
 
         /// Info button. Handles selection.
         case detailButton(Selection)
+        
+        /// Switch. Handles value change.
+        case switchToggle(value: Bool, ValueChange)
 
         /// Custom view
         case view(UIView)
@@ -43,6 +47,8 @@ public struct Row: Hashable, Equatable {
         public var view: UIView? {
             switch self {
             case .view(let view): return view
+            case .switchToggle(let value, let valueChange):
+                return SwitchAccessory(initialValue: value, valueChange: valueChange)
             default: return nil
             }
         }

--- a/Static/SwitchAccessory.swift
+++ b/Static/SwitchAccessory.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class SwitchAccessory : UISwitch {
+    typealias ValueChange = (Bool) -> ()
+    
+    init(initialValue: Bool, valueChange: (ValueChange)? = nil) {
+        self.valueChange = valueChange
+        super.init(frame: .zero)
+        setOn(initialValue, animated: false)
+        addTarget(self, action: #selector(valueChanged), for: .valueChanged)
+    }
+    
+    fileprivate init() {super.init(frame: .zero)}
+    fileprivate override init(frame: CGRect) {super.init(frame: frame)}
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var valueChange : ValueChange?
+    @objc func valueChanged() {
+        valueChange?(self.isOn)
+    }
+}


### PR DESCRIPTION
We added support for a 'switch' accessory type.

Note that the 'SwitchAccessory' subclass was necessary to bind a closure to .valueChanged (there are other ways to achieve this if you'd rather use objc associated objects)