### PR TITLE
adds new checkmark placeholder

### DIFF
--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -23,6 +23,10 @@ public struct Row: Hashable, Equatable {
         /// Checkmark
         case checkmark
 
+        /// Checkmark Placeholder.
+        /// Allows spacing to continue to work when switching back & forth between checked states.
+        case checkmarkPlaceholder
+
         /// Info button. Handles selection.
         case detailButton(Selection)
         
@@ -49,6 +53,8 @@ public struct Row: Hashable, Equatable {
             case .view(let view): return view
             case .switchToggle(let value, let valueChange):
                 return SwitchAccessory(initialValue: value, valueChange: valueChange)
+            case .checkmarkPlaceholder:
+                return UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
             default: return nil
             }
         }


### PR DESCRIPTION
We were running into an issue where if you toggled back & forth between checked/unchecked states, the content would abruptly shift back & forth for the user, on smaller screens like the 5s. (The problem didn't exhibit itself on larger screens like the X).

This allows the developer to opt-in to use a `checkmarkPlaceholder`, allowing Static to insert a placeholder appropriately sized blank `UIView` to hang out until a checkmark may appear in its place.

Before | After
------------ | -------------
![privacy_settings_checks - bug](https://user-images.githubusercontent.com/462870/40256831-cac6ff3e-5ab9-11e8-9765-fadf85315322.gif) | ![privacy_settings_checks - fix](https://user-images.githubusercontent.com/462870/40256834-d17d06c0-5ab9-11e8-87b9-5a4d59fdafe3.gif)

