### PR TITLE
Xcode10 Travis Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode9.3
+osx_image: xcode10
 xcode_project: Static.xcodeproj
 
 script: xcodebuild -scheme "$TRAVIS_XCODE_SCHEME" -sdk "$TRAVIS_XCODE_SDK" -destination "$DESTINATION" test


### PR DESCRIPTION
Problem:
Although building/testing fine locally, Travis CI job is failure due to old sdk.

Change:
Update yml osx_image

https://docs.travis-ci.com/user/reference/osx/
![screen shot 2018-09-26 at 11 29 03 am](https://user-images.githubusercontent.com/5083390/46100904-6daf1c00-c17f-11e8-81ca-badcb1b48e84.png)
