### PR TITLE
Pass the IndexPath to an EditAction's selection

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -71,11 +71,11 @@ class ViewController: TableViewController {
             ]),
             Section(header: "Editing", rows: [
                 Row(text: "Swipe this row", editActions: [
-                    Row.EditAction(title: "Warn", backgroundColor: .orange, selection: { [unowned self] in
-                        self.showAlert(title: "Warned.")
+                    Row.EditAction(title: "Warn", backgroundColor: .orange, selection: { [unowned self] (indexPath) in
+                        self.showAlert(title: "Warned at indexPath: \(indexPath).")
                     }),
-                    Row.EditAction(title: "Delete", style: .destructive, selection: { [unowned self] in
-                        self.showAlert(title: "Deleted.")
+                    Row.EditAction(title: "Delete", style: .destructive, selection: { [unowned self] (indexPath) in
+                        self.showAlert(title: "Deleted at indexPath: \(indexPath).")
                     })
                 ])
             ]),

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -246,7 +246,7 @@ extension DataSource: UITableViewDataSource {
         return row(at: indexPath)?.editActions.map {
             action in
             let rowAction = UITableViewRowAction(style: action.style, title: action.title) { (_, _) in
-                action.selection?()
+                action.selection?(indexPath)
             }
 
             // These calls have side effects when setting to nil

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -70,6 +70,7 @@ public struct Row: Hashable, Equatable {
     }
 
     public typealias Context = [String: Any]
+    public typealias EditActionSelection = (IndexPath) -> ()
 
     /// Representation of an editing action, when swiping to edit a cell.
     public struct EditAction {
@@ -86,9 +87,9 @@ public struct Row: Hashable, Equatable {
         public let backgroundEffect: UIVisualEffect?
         
         /// Invoked when selecting the action.
-        public let selection: Selection?
+        public let selection: EditActionSelection?
         
-        public init(title: String, style: UITableViewRowAction.Style = .default, backgroundColor: UIColor? = nil, backgroundEffect: UIVisualEffect? = nil, selection: Selection? = nil) {
+        public init(title: String, style: UITableViewRowAction.Style = .default, backgroundColor: UIColor? = nil, backgroundEffect: UIVisualEffect? = nil, selection: EditActionSelection? = nil) {
             self.title = title
             self.style = style
             self.backgroundColor = backgroundColor


### PR DESCRIPTION
Impetus for this change is that you can create `EditAction`s but when your selection closure is called, you don't have any information about what `Row` it was or what the `IndexPath` representing the row is.

So this passes the `IndexPath` to the `EditAction` closure, allowing you to do whatever you need to do to the backing data source for the row.

If there's another way to know 'what row did I just select an `EditAction` on' please let me know and I can abandon this idea but I'll update the Example project to show how this can be done.