### PR TITLE
Pass ‘Row’ model to selection handler

### DIFF
--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -292,7 +292,7 @@ extension DataSource: UITableViewDelegate {
         }
 
         if let row = row(at: indexPath) {
-            row.selection?()
+            row.selection?(row)
         }
 
         tableViewDelegate?.tableView?(tableView, didSelectRowAt: indexPath)
@@ -300,7 +300,7 @@ extension DataSource: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
         if let row = row(at: indexPath) {
-            row.accessory.selection?()
+            row.accessory.selection?(row)
         }
 
         tableViewDelegate?.tableView?(tableView, accessoryButtonTappedForRowWith: indexPath)

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Row or Accessory selection callback.
-public typealias Selection = () -> Void
+public typealias Selection = (Row) -> Void
 public typealias ValueChange = (Bool) -> ()
 public typealias SegmentedControlValueChange = (Int, Any?) -> ()
 

--- a/Static/Tests/DataSourceTests.swift
+++ b/Static/Tests/DataSourceTests.swift
@@ -92,14 +92,14 @@ class DataSourceTests: XCTestCase {
         XCTAssertFalse(dataSource.tableView(tableView, shouldHighlightRowAt: IndexPath(row: 0, section: 0)))
 
         dataSource.sections = [
-            Section(rows: [Row(text: "Cupcakes", selection: {})])
+            Section(rows: [Row(text: "Cupcakes", selection: { (row) in })])
         ]
         XCTAssertTrue(dataSource.tableView(tableView, shouldHighlightRowAt: IndexPath(row: 0, section: 0)))
     }
 
     func testSelection() {
         let expectation = self.expectation(description: "Selected")
-        let selection = {
+        let selection: Selection = { (row) in
             expectation.fulfill()
         }
 
@@ -112,7 +112,7 @@ class DataSourceTests: XCTestCase {
 
     func testAccessorySelection() {
         let expectation = self.expectation(description: "Accessory Selected")
-        let selection = {
+        let selection: Selection = { (row) in
             expectation.fulfill()
         }
 

--- a/Static/Tests/RowTests.swift
+++ b/Static/Tests/RowTests.swift
@@ -4,7 +4,7 @@ import Static
 class RowTests: XCTestCase {
 
     func testInit() {
-        let selection: Selection = {}
+        let selection: Selection = { (row) in }
         let context: Row.Context = [
             "Hello": "world"
         ]
@@ -36,7 +36,7 @@ class RowTests: XCTestCase {
     }
 
     func testInitWithSelectableAccessoryType() {
-        let selection: Selection = {}
+        let selection: Selection = { (row) in }
         let accessory: Row.Accessory = .detailButton(selection)
 
         let row = Row(accessory: accessory)


### PR DESCRIPTION
Access to the the row data (including the context dictionnary) within this handler can be useful.