### PR TITLE
Migrate to Swift 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode10
+osx_image: xcode10.2
 xcode_project: Static.xcodeproj
 
 script: xcodebuild -scheme "$TRAVIS_XCODE_SCHEME" -sdk "$TRAVIS_XCODE_SDK" -destination "$DESTINATION" test
@@ -9,4 +9,4 @@ matrix:
     - xcode_scheme: Static-iOS
       xcode_sdk: iphonesimulator
       env:
-        - DESTINATION="OS=10.1,name=iPhone 7 Plus"
+        - DESTINATION="OS=12.2,name=iPhone X"

--- a/Static.xcodeproj/project.pbxproj
+++ b/Static.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Venmo;
 				TargetAttributes = {
 					21826AA91B3F51A100AA9641 = {
@@ -293,7 +293,7 @@
 			};
 			buildConfigurationList = 21826AA41B3F51A100AA9641 /* Build configuration list for PBXProject "Static" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -409,6 +409,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -468,6 +469,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/Static.xcodeproj/project.pbxproj
+++ b/Static.xcodeproj/project.pbxproj
@@ -279,15 +279,15 @@
 				TargetAttributes = {
 					21826AA91B3F51A100AA9641 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 					21826AB31B3F51A100AA9641 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 					36748D4E1B5034EC0046F207 = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -535,7 +535,7 @@
 				PRODUCT_NAME = Static;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -557,7 +557,7 @@
 				PRODUCT_NAME = Static;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -568,7 +568,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.static.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -580,7 +580,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.static.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -593,7 +593,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -607,7 +607,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Static.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Static.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Static.xcodeproj/xcshareddata/xcschemes/Static-iOS.xcscheme
+++ b/Static.xcodeproj/xcshareddata/xcschemes/Static-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -311,6 +311,7 @@ extension UITableView.Style {
         switch self {
         case .plain: return 0
         case .grouped: return UITableView.automaticDimension
+        @unknown default: return UITableView.automaticDimension
         }
     }
 }

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -148,8 +148,8 @@ public struct Row: Hashable, Equatable {
         return cellClass.description()
     }
 
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
     }
 
 

--- a/Static/Section.swift
+++ b/Static/Section.swift
@@ -58,8 +58,8 @@ public struct Section: Hashable, Equatable {
     /// Section index title
     public var indexTitle: String?
 
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
     }
 
 


### PR DESCRIPTION
## ℹ️ Changes

- Update Static.xcodeproj by migrating to Swift 5.0
- Replace hashValue computed property with hash(into:) method in Row.swift and Section.swift
- Update UITableView.Style extension computed property defaultSectionExtremityHeight by adding @unknown default handling to switch statement
- Migrate the deprecated English localization language to the new one named en
- Set CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
- Update .travis.yml file to use Xcode 10.2