### PR TITLE
Add support for more modern (non-deprecated) table view swipe API

### DIFF
--- a/Static.podspec
+++ b/Static.podspec
@@ -1,14 +1,13 @@
 Pod::Spec.new do |spec|
   spec.name = 'Static'
-  spec.version = '4.0.2'
+  spec.version = '4.1.0'
   spec.summary = 'Simple static table views for iOS in Swift.'
   spec.description = 'Static provides simple static table views for iOS in Swift.'
   spec.homepage = 'https://github.com/venmo/static'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.source = { git: 'https://github.com/venmo/Static.git', tag: "v#{spec.version}" }
   spec.author = { 'Venmo' => 'ios@venmo.com', 'Sam Soffes' => 'sam@soff.es' }
-
-  spec.platform = :ios, '8.0'
+  spec.ios.deployment_target = '11.0'
   spec.frameworks = 'UIKit'
   spec.source_files = 'Static/*.{swift,h}'
 end

--- a/Static/DataSource.swift
+++ b/Static/DataSource.swift
@@ -264,6 +264,22 @@ extension DataSource: UITableViewDataSource {
             return rowAction
         }
     }
+    
+    public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        return row(at: indexPath)?.leadingSwipeActionsConfiguration.map {
+            let actionsConfiguration = UISwipeActionsConfiguration(actions: $0.actions)
+            actionsConfiguration.performsFirstActionWithFullSwipe = $0.performsFirstActionWithFullSwipe
+            return actionsConfiguration
+        }
+    }
+    
+    public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        return row(at: indexPath)?.trailingSwipeActionsConfiguration.map {
+            let actionsConfiguration = UISwipeActionsConfiguration(actions: $0.actions)
+            actionsConfiguration.performsFirstActionWithFullSwipe = $0.performsFirstActionWithFullSwipe
+            return actionsConfiguration
+        }
+    }
 
     public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         guard let sectionIndexTitles = sectionIndexTitles, sectionIndexTitles.count >= sections.count else { return nil }

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -103,6 +103,19 @@ public struct Row: Hashable, Equatable {
             self.selection = selection
         }
     }
+    
+    /// Representation of the set of actions to perform when swiping on rows of a table.
+    public struct SwipeActionsConfiguration {
+        /// The swipe actions.
+        public let actions: [UIContextualAction]
+        
+        /// A Boolean value indicating whether a full swipe automatically performs the first action.
+        public var performsFirstActionWithFullSwipe: Bool = true
+        
+        public init(actions: [UIContextualAction]) {
+            self.actions = actions
+        }
+    }
 
     // MARK: - Properties
 
@@ -137,9 +150,15 @@ public struct Row: Hashable, Equatable {
     
     /// Actions to show when swiping the cell, such as Delete.
     public var editActions: [EditAction]
+    
+    /// Returns the swipe actions to display on the leading edge of the row.
+    public var leadingSwipeActionsConfiguration: SwipeActionsConfiguration?
+    
+    /// Returns the swipe actions to display on the trailing edge of the row.
+    public var trailingSwipeActionsConfiguration: SwipeActionsConfiguration?
 
     var canEdit: Bool {
-        return editActions.count > 0
+        return (editActions.count > 0) || (leadingSwipeActionsConfiguration != nil) || (trailingSwipeActionsConfiguration != nil)
     }
 
     var isSelectable: Bool {


### PR DESCRIPTION
UITableViewRowAction and it’s associated methods have been deprecated in favor of the new UISwipeActionsConfiguration object which can be configured on the trailing and leading edges of a table view cell.

This API is available on iOS 11.0 onwards. The cleanest way to support this is to bump the deployment target to iOS 11.