### PR TITLE
Adding accessibility properties

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -9,7 +9,7 @@ Simple static table views for iOS in Swift. Static's goal is to separate model d
 
 | Swift Version | Static Version |
 | ------------- | -------------- |
-| 5.0+          | 4.0.0          |
+| 5.0+          | 4.0.2          |
 | 4.2+          | 3.0.1          |
 | 3.2+          | 2.1            |
 | 3.0.1         | 2.0.1          |

--- a/Static.podspec
+++ b/Static.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Static'
-  spec.version = '4.0.1'
+  spec.version = '4.0.2'
   spec.summary = 'Simple static table views for iOS in Swift.'
   spec.description = 'Static provides simple static table views for iOS in Swift.'
   spec.homepage = 'https://github.com/venmo/static'

--- a/Static/Cell.swift
+++ b/Static/Cell.swift
@@ -15,6 +15,8 @@ extension Cell {
 
 extension Cell where Self: UITableViewCell {
     public func configure(row: Row) {
+        accessibilityTraits = row.accessibilityTraits ?? accessibilityTraits
+        accessibilityLabel = row.accessibilityLabel ?? accessibilityLabel
         accessibilityIdentifier = row.accessibilityIdentifier
         textLabel?.text = row.text
         detailTextLabel?.text = row.detailText

--- a/Static/Cell.swift
+++ b/Static/Cell.swift
@@ -16,7 +16,7 @@ extension Cell {
 extension Cell where Self: UITableViewCell {
     public func configure(row: Row) {
         accessibilityTraits = row.accessibilityTraits ?? accessibilityTraits
-        accessibilityLabel = row.accessibilityLabel ?? accessibilityLabel
+        accessibilityLabel = row.accessibilityLabel
         accessibilityIdentifier = row.accessibilityIdentifier
         textLabel?.text = row.text
         detailTextLabel?.text = row.detailText

--- a/Static/Row.swift
+++ b/Static/Row.swift
@@ -106,8 +106,10 @@ public struct Row: Hashable, Equatable {
 
     // MARK: - Properties
 
-    /// The row's accessibility identifier.
+    /// The row's accessibility properties.
     public var accessibilityIdentifier: String?
+    public var accessibilityLabel: String?
+    public var accessibilityTraits: UIAccessibilityTraits?
 
     /// Unique identifier for the row.
     public let uuid: String
@@ -156,7 +158,9 @@ public struct Row: Hashable, Equatable {
     // MARK: - Initializers
 
     public init(text: String? = nil, detailText: String? = nil, selection: Selection? = nil,
-        image: UIImage? = nil, accessory: Accessory = .none, cellClass: Cell.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], uuid: String = UUID().uuidString, accessibilityIdentifier: String? = nil) {
+        image: UIImage? = nil, accessory: Accessory = .none, cellClass: Cell.Type? = nil, context: Context? = nil, editActions: [EditAction] = [], uuid: String = UUID().uuidString, accessibilityIdentifier: String? = nil, accessibilityLabel: String? = nil, accessibilityTraits: UIAccessibilityTraits? = nil) {
+        self.accessibilityTraits = accessibilityTraits
+        self.accessibilityLabel = accessibilityLabel
         self.accessibilityIdentifier = accessibilityIdentifier
         self.uuid = uuid
         self.text = text

--- a/Static/Tests/RowTests.swift
+++ b/Static/Tests/RowTests.swift
@@ -8,13 +8,17 @@ class RowTests: XCTestCase {
         let context: Row.Context = [
             "Hello": "world"
         ]
+        let accessibilityTraits: UIAccessibilityTraits = [.button, .staticText]
 
-        let row = Row(text: "Title", detailText: "Detail", selection: selection, cellClass: ButtonCell.self, context: context, uuid: "1234", accessibilityIdentifier: "TitleRow")
+        let row = Row(text: "Title", detailText: "Detail", selection: selection, cellClass: ButtonCell.self, context: context, uuid: "1234", accessibilityIdentifier: "TitleRow", accessibilityLabel: "TitleRowAccessibilityLabel", accessibilityTraits: accessibilityTraits)
+
         XCTAssertEqual("1234", row.uuid)
         XCTAssertEqual("Title", row.text!)
         XCTAssertEqual("Detail", row.detailText!)
         XCTAssertEqual("world", row.context?["Hello"] as? String)
         XCTAssertEqual("TitleRow", row.accessibilityIdentifier)
+        XCTAssertEqual("TitleRowAccessibilityLabel", row.accessibilityLabel)
+        XCTAssertEqual(accessibilityTraits, row.accessibilityTraits)
     }
 
     func testInitWithImage() {
@@ -53,7 +57,7 @@ class RowTests: XCTestCase {
 
     func testHashable() {
         let row = Row()
-        var hash = [
+        let hash = [
             row: "hi"
         ]
 

--- a/Static/Tests/SectionTests.swift
+++ b/Static/Tests/SectionTests.swift
@@ -22,7 +22,7 @@ class SectionTests: XCTestCase {
 
     func testHashable() {
         let section = Section()
-        var hash = [
+        let hash = [
             section: "hi"
         ]
 


### PR DESCRIPTION
Adding some more properties to the initializer, in order to set `accessibilityTraits` and `accessibilityLabel` to the rows.